### PR TITLE
Support reading art event auxiliaries

### DIFF
--- a/EventAuxReader.h
+++ b/EventAuxReader.h
@@ -1,24 +1,38 @@
 #if !defined(EventAuxReader_h)
 #define EventAuxReader_h
 
+#include <cassert>
+
 #include "EventIdentifier.h"
+#include "art/EventAuxiliary.h"
 #include "cms/EventAuxiliary.h"
 
 namespace cce::tf {
+
+inline EventIdentifier cmsEventID(void** address) {
+   assert(address);
+   auto aux = *reinterpret_cast<edm::EventAuxiliary**>(address);
+   return EventIdentifier{aux->run(), aux->luminosityBlock(), aux->event()};
+}
+
+inline EventIdentifier artEventID(void** address) {
+  assert(address);
+  auto aux = *reinterpret_cast<art::EventAuxiliary**>(address);
+  return EventIdentifier{aux->run(), aux->subRun(), aux->event()};
+}
+
 class EventAuxReader {
 public:
-  EventAuxReader(void** iAddress): address_(iAddress){}
+  EventAuxReader(std::function<EventIdentifier()> f={}): func_(std::move(f)){}
 
   EventIdentifier doWork() {
-    if(address_) {
-      auto aux = *reinterpret_cast<edm::EventAuxiliary**>(address_); 
-      return EventIdentifier{aux->run(), aux->luminosityBlock(), aux->event()};
-    } else {
+    if(func_) return func_();
       return EventIdentifier{0,0,0};
-    }
+
+
   }
 private:
-  void** address_;
+  std::function<EventIdentifier()> func_;
 };
 }
 #endif

--- a/RepeatingRootSource.cc
+++ b/RepeatingRootSource.cc
@@ -69,7 +69,16 @@ RepeatingRootSource::RepeatingRootSource(std::string const& iName, unsigned int 
   for(int i=0; i<nUniqueEvents_; ++i) {
     fillBuffer(i, dataBuffersPerEvent_[i], branches);
     if(eventAuxIndex != -1) {
-      identifierPerEvent_[i] = EventAuxReader(&dataBuffersPerEvent_[i][eventAuxIndex].address_).doWork();
+      auto addr = &dataBuffersPerEvent_[i][eventAuxIndex].address_;
+      EventAuxReader aux_reader;
+      if (file_->GetKey("RootFileDB")) {
+        // art/ROOT file
+        aux_reader = EventAuxReader([addr]{ return artEventID(addr); });
+      } else {
+        // CMSSW file
+        aux_reader = EventAuxReader([addr]{ return cmsEventID(addr); });
+      }
+      identifierPerEvent_[i] = aux_reader.doWork();
       //std::cout <<"id "<<identifierPerEvent_[i].event<<std::endl;
     } else if(eventIDBranch) {
       eventIDBranch->SetAddress(&identifierPerEvent_[i]);

--- a/RootSource.cc
+++ b/RootSource.cc
@@ -38,7 +38,14 @@ RootSource::RootSource(std::string const& iName) :
 			       &delayedReader_);
     branches_.emplace_back(b);
     if(eventAuxiliaryBranchName == dataProducts_.back().name()) {
-      eventAuxReader_ = EventAuxReader(dataProducts_.back().address());
+      auto addr = dataProducts_.back().address();
+      if (file_->GetKey("RootFileDB")) {
+        // art/ROOT file
+        eventAuxReader_ = EventAuxReader([addr]{ return artEventID(addr); });
+      } else {
+        // CMSSW file
+        eventAuxReader_ = EventAuxReader([addr]{ return cmsEventID(addr); });
+      }
     }
   }
   if(not eventAuxReader_) {

--- a/SerialRootSource.cc
+++ b/SerialRootSource.cc
@@ -36,7 +36,14 @@ SerialRootSource::SerialRootSource(unsigned iNLanes, unsigned long long iNEvents
     branches_.emplace_back(b);
     if(eventAuxiliaryBranchName == b->GetName()) {
       eventAuxBranch_ = b;
-      eventAuxReader_ = EventAuxReader(reinterpret_cast<void**>(b->GetAddress()));
+      auto addr = reinterpret_cast<void**>(b->GetAddress());
+      if (file_->GetKey("RootFileDB")) {
+        // art/ROOT file
+        eventAuxReader_ = EventAuxReader([addr]{ return artEventID(addr); });
+      } else {
+        // CMSSW file
+        eventAuxReader_ = EventAuxReader([addr]{ return cmsEventID(addr); });
+      }
     }
   }
 

--- a/art/EventAuxiliary.h
+++ b/art/EventAuxiliary.h
@@ -1,0 +1,40 @@
+#ifndef canvas_Persistency_Provenance_EventAuxiliary_h
+#define canvas_Persistency_Provenance_EventAuxiliary_h
+// vim: set sw=2 expandtab :
+
+#include "EventID.h"
+#include "Timestamp.h"
+
+namespace art {
+  class EventAuxiliary {
+  public:
+    enum ExperimentType {
+      Any = 0,
+      Align = 1,
+      Calib = 2,
+      Cosmic = 3,
+      Data = 4,
+      Mc = 5,
+      Raw = 6,
+      Test = 7
+    };
+
+    EventAuxiliary();
+
+    RunNumber_t run() const noexcept { return id_.run(); }
+    SubRunNumber_t subRun() const noexcept { return id_.subRun(); }
+    EventNumber_t event() const noexcept { return id_.event(); }
+
+  private:
+    EventID id_{};
+    Timestamp time_{}; // Unused
+    bool isRealData_{false}; // Unused
+    ExperimentType experimentType_{Any}; // Unused
+  };
+} // namespace art
+
+#endif /* canvas_Persistency_Provenance_EventAuxiliary_h */
+
+// Local Variables:
+// mode: c++
+// End:

--- a/art/EventID.h
+++ b/art/EventID.h
@@ -1,0 +1,28 @@
+#ifndef canvas_Persistency_Provenance_EventID_h
+#define canvas_Persistency_Provenance_EventID_h
+
+// An EventID labels an unique readout of the data acquisition system,
+// which we call an "event".
+
+#include "SubRunID.h"
+
+#include <cstdint>
+
+namespace art {
+  class EventID {
+  public:
+    RunNumber_t run() const { return subRun_.run(); }
+    SubRunNumber_t subRun() const { return subRun_.subRun(); }
+    EventNumber_t event() const { return event_; }
+
+  private:
+    SubRunID subRun_{};
+    EventNumber_t event_{IDNumber<Level::Event>::invalid()};
+  };
+}
+
+#endif /* canvas_Persistency_Provenance_EventID_h */
+
+// Local Variables:
+// mode: c++
+// End:

--- a/art/IDNumber.h
+++ b/art/IDNumber.h
@@ -1,0 +1,128 @@
+#ifndef canvas_Persistency_Provenance_IDNumber_h
+#define canvas_Persistency_Provenance_IDNumber_h
+// vim: set sw=2 expandtab :
+
+#include "Level.h"
+#include <cstdint>
+
+namespace art {
+
+  template <Level>
+  struct IDNumber;
+
+  template <>
+  struct IDNumber<Level::Event> {
+    using type = std::uint32_t;
+    static constexpr type
+    invalid() noexcept
+    {
+      return -1u;
+    }
+    static constexpr type
+    max_valid() noexcept
+    {
+      return invalid() - 1u;
+    }
+    static constexpr type
+    flush_value() noexcept
+    {
+      return max_valid();
+    }
+    static constexpr type
+    max_natural() noexcept
+    {
+      return flush_value() - 1u;
+    }
+    static constexpr type
+    first() noexcept
+    {
+      return 1u;
+    }
+    static type
+    next(type const n) noexcept
+    {
+      return n + 1u;
+    }
+  };
+
+  template <>
+  struct IDNumber<Level::SubRun> {
+    using type = std::uint32_t;
+    static constexpr type
+    invalid() noexcept
+    {
+      return -1u;
+    }
+    static constexpr type
+    max_valid() noexcept
+    {
+      return invalid() - 1u;
+    }
+    static constexpr type
+    flush_value() noexcept
+    {
+      return max_valid();
+    }
+    static constexpr type
+    max_natural() noexcept
+    {
+      return flush_value() - 1u;
+    }
+    static constexpr type
+    first() noexcept
+    {
+      return 0u;
+    }
+  };
+
+  template <>
+  struct IDNumber<Level::Run> {
+    using type = std::uint32_t;
+    static constexpr type
+    invalid() noexcept
+    {
+      return -1u;
+    }
+    static constexpr type
+    max_valid() noexcept
+    {
+      return invalid() - 1u;
+    }
+    static constexpr type
+    flush_value() noexcept
+    {
+      return max_valid();
+    }
+    static constexpr type
+    max_natural() noexcept
+    {
+      return flush_value() - 1u;
+    }
+    static constexpr type
+    first() noexcept
+    {
+      return 1u;
+    }
+  };
+
+  template <Level L>
+  using IDNumber_t = typename IDNumber<L>::type;
+
+  template <Level L = Level::Event>
+  constexpr bool
+  is_valid(IDNumber_t<L> const id) noexcept
+  {
+    return id != IDNumber<L>::invalid();
+  }
+
+  using EventNumber_t = IDNumber_t<Level::Event>;
+  using SubRunNumber_t = IDNumber_t<Level::SubRun>;
+  using RunNumber_t = IDNumber_t<Level::Run>;
+
+} // namespace art
+
+#endif /* canvas_Persistency_Provenance_IDNumber_h */
+
+// Local variables:
+// mode: c++
+// End:

--- a/art/Level.h
+++ b/art/Level.h
@@ -1,0 +1,114 @@
+#ifndef canvas_Utilities_Level_h
+#define canvas_Utilities_Level_h
+// vim: set sw=2 expandtab :
+
+#include <cassert>
+#include <cstdint>
+#include <ostream>
+#include <type_traits>
+
+namespace art {
+
+  // The outer-most level must be 0.
+  enum class Level {
+    Job = 0,
+    InputFile,
+    Run,
+    SubRun,
+    Event,
+    NumNestingLevels,
+    ReadyToAdvance
+  };
+
+  // The following facility is to translate from the scoped enumerator
+  // to the value represented by the underlying type.
+  constexpr auto
+  underlying_value(Level const l) noexcept
+  {
+    return static_cast<std::underlying_type_t<Level>>(l);
+  }
+
+  constexpr auto
+  highest_level() noexcept
+  {
+    return Level{0};
+  }
+
+  constexpr auto
+  level_up(Level const l) noexcept
+  {
+    return Level{underlying_value(l) - 1};
+  }
+
+  constexpr auto
+  most_deeply_nested_level() noexcept
+  {
+    return level_up(Level::NumNestingLevels);
+  }
+
+  constexpr auto
+  level_down(Level const l) noexcept
+  {
+    return Level{underlying_value(l) + 1};
+  }
+
+  constexpr bool
+  is_above_most_deeply_nested_level(Level const l) noexcept
+  {
+    return underlying_value(l) < underlying_value(most_deeply_nested_level());
+  }
+
+  constexpr bool
+  is_most_deeply_nested_level(Level const l) noexcept
+  {
+    return l == most_deeply_nested_level();
+  }
+
+  constexpr bool
+  is_highest_level(Level const l) noexcept
+  {
+    return l == highest_level();
+  }
+
+  constexpr bool
+  is_level_contained_by(Level const l1, Level const l2) noexcept
+  {
+    return underlying_value(l1) > underlying_value(l2);
+  }
+
+  inline std::ostream&
+  operator<<(std::ostream& os, Level const l)
+  {
+    switch (l) {
+    case Level::Job:
+      os << "Job";
+      break;
+    case Level::InputFile:
+      os << "InputFile";
+      break;
+    case Level::Run:
+      os << "Run";
+      break;
+    case Level::SubRun:
+      os << "SubRun";
+      break;
+    case Level::Event:
+      os << "Event";
+      break;
+    case Level::NumNestingLevels:
+      os << underlying_value(Level::NumNestingLevels);
+      break;
+    case Level::ReadyToAdvance:
+      os << "ReadyToAdvance";
+      break;
+    }
+    return os;
+  }
+
+} // namespace art
+
+#endif /* canvas_Utilities_Level_h */
+
+// Local variables:
+// mode: c++
+// End:

--- a/art/RunID.h
+++ b/art/RunID.h
@@ -1,0 +1,27 @@
+#ifndef canvas_Persistency_Provenance_RunID_h
+#define canvas_Persistency_Provenance_RunID_h
+
+//
+// A RunID represents a unique period of operation of the data
+// acquisition system, which we call a "run".
+//
+// Each RunID contains a fixed-size unsigned integer, the run number.
+//
+
+#include "IDNumber.h"
+
+namespace art {
+  class RunID {
+  public:
+    RunNumber_t run() const { return run_; }
+
+  private:
+    RunNumber_t run_{IDNumber<Level::Run>::invalid()};
+  };
+} // namespace art
+
+#endif /* canvas_Persistency_Provenance_RunID_h */
+
+// Local Variables:
+// mode: c++
+// End:

--- a/art/SubRunID.h
+++ b/art/SubRunID.h
@@ -1,0 +1,25 @@
+#ifndef canvas_Persistency_Provenance_SubRunID_h
+#define canvas_Persistency_Provenance_SubRunID_h
+
+// A SubRunID represents a unique period within a run.
+
+#include "RunID.h"
+
+namespace art {
+
+  class SubRunID {
+  public:
+    RunNumber_t run() const { return run_.run(); }
+    SubRunNumber_t subRun() const { return subRun_; }
+
+  private:
+    RunID run_{};
+    SubRunNumber_t subRun_{IDNumber<Level::SubRun>::invalid()};
+  };
+}
+
+#endif /* canvas_Persistency_Provenance_SubRunID_h */
+
+// Local Variables:
+// mode: c++
+// End:

--- a/art/Timestamp.h
+++ b/art/Timestamp.h
@@ -1,0 +1,45 @@
+#ifndef canvas_Persistency_Provenance_Timestamp_h
+#define canvas_Persistency_Provenance_Timestamp_h
+
+#include <cstdint>
+#include <string>
+
+namespace art {
+  using TimeValue_t = std::uint64_t;
+
+  class Timestamp {
+  public:
+    constexpr Timestamp(TimeValue_t const iValue)
+      : timeLow_{static_cast<std::uint32_t>(lowMask() & iValue)}
+      , timeHigh_{static_cast<std::uint32_t>(iValue >> 32)}
+    {}
+
+    constexpr Timestamp()
+      : timeLow_{invalidTimestamp().timeLow_}
+      , timeHigh_{invalidTimestamp().timeHigh_}
+    {}
+
+    // ---------- static member functions --------------------
+    static constexpr Timestamp
+    invalidTimestamp()
+    {
+      return Timestamp{0};
+    }
+
+  private:
+    std::uint32_t timeLow_;
+    std::uint32_t timeHigh_;
+
+    static constexpr TimeValue_t
+    lowMask()
+    {
+      return 0xFFFFFFFF;
+    }
+  };
+
+}
+#endif /* canvas_Persistency_Provenance_Timestamp_h */
+
+// Local Variables:
+// mode: c++
+// End:


### PR DESCRIPTION
I'm seeing one test failure:

```
11: Test command: /usr/bin/bash "-c" "/nashome/k/knoepfel/scratch/build-root-serialization-old/threaded_io_test TestProductsSource 1 1 0 10 PDSOutputer=test_prod_unroll.pds:serializationAlgorithm=Unrolled; /nashome/k/knoepfel/scratch/build-root-serialization-old/threaded_io_test SharedPDSSource=test_prod_unroll.pds 1 1 0 10 TestProductsOutputer"
11: Test timeout computed to be: 10000000
11: begin warmup
11: finished warmup
11: ----------
11: Source TestProductsSource
11: Outputer PDSOutputer=test_prod_unroll.pds:serializationAlgorithm=Unrolled
11: # threads 1
11: # concurrent events 1
11: time scale 0
11: use ROOT IMT false
11: Event processing time: 426us
11: number events: 10
11: ----------
11: 
11: Source time: N/A
11: PDSOutputer
11:   total serial time at end event: 12us
11:   total parallel time at end event: 227us
11: Serialization total time: 32us
11: Serialization times
11: time: 22us 68.75%   name: floats
11: time: 10us 31.25%   name: ints
11: begin warmup
11: threaded_io_test: /nashome/k/knoepfel/srcs/root_serialization/pds_reading.cc:39: {anonymous}::Preamble {anonymous}::readPreamble(std::istream&): Assertion `3141592*256+1 == header[0]' failed.
11: /usr/bin/bash: line 1: 47180 Aborted                 /nashome/k/knoepfel/scratch/build-root-serialization-old/threaded_io_test SharedPDSSource=test_prod_unroll.pds 1 1 0 10 TestProductsOutputer
1/1 Test #11: TestProductsPDSUnrolled ..........***Failed    1.50 sec
```